### PR TITLE
Apply PHP syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ so feel free do it in your app service provider.
 But if you don't want to do it right now, 
 you can use `Matchish\ElasticSearchServiceProvider` from the package.  
 Register the provider, adding to `config/app.php`
-```
+```php
 'providers' => [
     // Other Service Providers
 
@@ -105,7 +105,7 @@ And for default settings
 To speed up import you can eager load relations on import using global scopes.
 
 You should configure `ImportSourceFactory` in your service provider(`register` method)
-```
+```php
 use Matchish\ScoutElasticSearch\Searchable\ImportSourceFactory;
 ...
 public function register(): void


### PR DESCRIPTION
Noticed the first couple of PHP examples don't have syntax highlighting (the later ones do).